### PR TITLE
Make `npm start` work.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "This is a bot for Commands and stuff",
   "main": "index.js",
   "scripts": {
-    "test": "%test"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "tennu config.json -v"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I also changed the test back to the default. The "scripts" property of package.json runs sh/batch commands. The reason `tennu` works in there as an executable is because `npm` sets up the PATH for it properly.
